### PR TITLE
Automatically calculate monthly hours

### DIFF
--- a/conf.py
+++ b/conf.py
@@ -6,14 +6,14 @@ import datetime
 
 ### BASICS ###
 
-name = "Max Mustermann"
-department = "MA"
+name = "Luka Rancic"
+department = "SFB/TRR 109"
 hours_each_month = 60
 
 year = 2022
 # Change the second entry (month) and the third (day)
-start_date = datetime.date(year, 1, 1)
-end_date = datetime.date(year, 12, 31)
+start_date = datetime.date(year, 8, 26)
+end_date = datetime.date(year, 11, 15)
 
 max_hours = 6
 min_hours = 0
@@ -21,7 +21,7 @@ min_hours = 0
 ### ADVANCED ###
 
 # Values between 0 - 6, representing the weekdays, Mon = 0, Sun = 6
-black_days = [5, 6]
+black_days = [6]
 # Keys between 0 - 6, Values positive floats, i.e. "0": 2.0
 event_days = {
     "0": 2,
@@ -40,6 +40,8 @@ xlsx_input_file = "zeitbogen.xlsx"
 xlsx_output_file = "output.xlsx"
 
 days_each_week = 7 - len(black_days)
+
+number_of_work_months = sum([1 if start_date.month <= x + 1 <= end_date.month else 0 for x in range(12)])
 
 weekday_map = ["Mon", "Tue", "Wed", "Thu", "Fri", "Sat", "Sun"]
 

--- a/generate_hours.py
+++ b/generate_hours.py
@@ -120,12 +120,12 @@ def write_output_file(filename, hours):
 
 def convert_info_to_dict(result_hours, days) -> dict:
     info = {
-        "expected_hours": 12 * hours_each_month,
+        "expected_hours": int(hours_each_month * number_of_work_months),
         "actual_hours": round(sum([x.sum() for x in result_hours])),
-        "expected_workdays": days,
+        "expected_workdays": days * number_of_work_months / 12,
         "actual_workdays": sum([(x != 0).sum() for x in result_hours]),
-        "black_days": 52 * len(black_days),
-        "event_days": 52 * len(event_days),
+        "black_days": int(52 * len(black_days) * number_of_work_months / 12),
+        "event_days": int(52 * len(event_days) * number_of_work_months / 12),
         "expected_max_hours": max_hours,
         "actual_max_hours": round(max([x.max() for x in result_hours]), 3),
         "expected_min_hours": min_hours,

--- a/generate_xlsx.py
+++ b/generate_xlsx.py
@@ -47,8 +47,11 @@ def get_time_for_date():
 def set_header_data(sheet, month):
     sheet.cell(3, 2).value = datetime.date(year, month, 1)
     sheet.cell(3, 5).value = name
-    sheet.cell(4, 2).value = hours_each_month
+    sheet.cell(4, 2).value = 0
     sheet.cell(4, 5).value = department
+
+    if start_date.month <= month <= end_date.month:
+        sheet.cell(4, 2).value = hours_each_month
 
 
 def set_hour(sheet, hour, cell):
@@ -69,10 +72,14 @@ def convert_info_to_dict(data) -> dict:
     hours = [sum([float(h[2]) for h in x]) for x in data]
     monthly_hours_unrounded = [sum(float(h[2]) for h in x) for x in data]
     monthly_hours = [round(x) for x in monthly_hours_unrounded]
+    expected_monthly_hours = [
+        hours_each_month if start_date.month <= i + 1 <= end_date.month else 0
+        for i in range(12)
+    ]
     info = {
         "total_hours": round(sum(hours)),
         "monthly_hours": monthly_hours,
-        "expected_month_hour": hours_each_month,
+        "expected_month_hour": expected_monthly_hours,
         "start_date": start_date,
         "end_date": end_date,
     }

--- a/main.py
+++ b/main.py
@@ -56,7 +56,8 @@ def print_info_xlsx(info):
         "Dec",
     ]
     for i in range(len(months)):
-        diff = round(info["monthly_hours"][i] - info["expected_month_hour"])
+        diff = round(info["monthly_hours"][i] - info["expected_month_hour"][i])
+
         sign = "-" if diff < 0 else "+"
         print(
             "{}: {}, {} {}".format(months[i], info["monthly_hours"][i], sign, abs(diff))


### PR DESCRIPTION
Closes #10 

Calculate monthly hours based on if the month is in the range of `start_date` and `end_date`.

Also updated the output of `main.py` to reflect the dates more accurately.